### PR TITLE
SVG position adjustment within NAV to correct FF display

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -850,10 +850,11 @@ nav.nav-block ul li {
 }
 
 nav.nav-block svg {
-	width: auto;
+	width: 100%;
 	height: 6.5rem;
 	position: absolute;
 	top: 1.5em;
+	left: 0;
 	transition: all .3s ease;
 }
 

--- a/style.css
+++ b/style.css
@@ -875,10 +875,11 @@ nav.nav-block ul li {
 }
 
 nav.nav-block svg {
-	width: auto;
+	width: 100%;
 	height: 6.5rem;
 	position: absolute;
 	top: 1.5em;
+	left: 0;
 	-webkit-transition: all .3s ease;
 	transition: all .3s ease;
 }


### PR DESCRIPTION
changed width of SVG icons to 100% so they wouldn't be offset in Firefox.